### PR TITLE
Retry and delay support

### DIFF
--- a/ledgerx/__init__.py
+++ b/ledgerx/__init__.py
@@ -3,7 +3,10 @@ import os
 # settings
 API_BASE = "https://api.ledgerx.com"
 LEGACY_API_BASE = "https://trade.ledgerx.com/api"
-DELAY_SECONDS = 0.0
+
+DELAY_SECONDS = 0.01
+DEFAULT_LIMIT = 200
+
 
 # configurations
 api_key = None

--- a/ledgerx/contracts.py
+++ b/ledgerx/contracts.py
@@ -5,8 +5,8 @@ from ledgerx.util import gen_url, unique_values_from_key
 
 
 class Contracts:
-    default_list_params = dict(active=True)
-    default_list_traded = dict(derivative_type=None, asset=None)
+    default_list_params = dict(limit=DEFAULT_LIMIT, active=True)
+    default_list_traded = dict(limit=DEFAULT_LIMIT, derivative_type=None, asset=None)
 
     @classmethod
     def list(cls, params: Dict = {}) -> List[Dict]:

--- a/ledgerx/contracts.py
+++ b/ledgerx/contracts.py
@@ -3,11 +3,13 @@ from ledgerx.http_client import HttpClient
 from ledgerx.generic_resource import GenericResource
 from ledgerx.util import gen_url, unique_values_from_key
 from ledgerx import DEFAULT_LIMIT
+from ledgerx import DELAY_SECONDS
 
 
 class Contracts:
     default_list_params = dict(limit=DEFAULT_LIMIT, active=True)
     default_list_traded = dict(limit=DEFAULT_LIMIT, derivative_type=None, asset=None)
+    default_trading_contracts_delay = DELAY_SECONDS
 
     @classmethod
     def list(cls, params: Dict = {}) -> List[Dict]:
@@ -22,7 +24,7 @@ class Contracts:
         include_api_key = False
         url = gen_url("/trading/contracts")
         qps = {**cls.default_list_params, **params}
-        res = HttpClient.get(url, qps, include_api_key, 0, 6)
+        res = HttpClient.get(url, qps, include_api_key)
         return res.json()
 
     @classmethod
@@ -82,7 +84,7 @@ class Contracts:
         include_api_key = False
         url = gen_url("/trading/contracts")
         qps = {**cls.default_list_params, **params}
-        return GenericResource.list_all(url, qps, include_api_key)
+        return GenericResource.list_all(url, qps, include_api_key, 0, cls.default_trading_contracts_delay)
 
     @classmethod
     def next(cls, next_url: str) -> Dict:

--- a/ledgerx/contracts.py
+++ b/ledgerx/contracts.py
@@ -2,6 +2,7 @@ from typing import List, Dict
 from ledgerx.http_client import HttpClient
 from ledgerx.generic_resource import GenericResource
 from ledgerx.util import gen_url, unique_values_from_key
+from ledgerx import DEFAULT_LIMIT
 
 
 class Contracts:

--- a/ledgerx/contracts.py
+++ b/ledgerx/contracts.py
@@ -21,7 +21,7 @@ class Contracts:
         include_api_key = False
         url = gen_url("/trading/contracts")
         qps = {**cls.default_list_params, **params}
-        res = HttpClient.get(url, qps, include_api_key)
+        res = HttpClient.get(url, qps, include_api_key, 0, 6)
         return res.json()
 
     @classmethod

--- a/ledgerx/generic_resource.py
+++ b/ledgerx/generic_resource.py
@@ -24,16 +24,21 @@ class GenericResource:
         params: Dict = {},
         include_api_key: bool = False,
         max_fetches: int = 0,
+        delay: float = DELAY_SECONDS,
     ) -> List[Dict]:
         elements = []
 
         json_data = cls.list(url, params, include_api_key)
         elements.extend(json_data["data"])
+        fetches = 1
 
         while has_next_url(json_data):
-            sleep(DELAY_SECONDS)
+            if max_fetches > 0 and fetches >= max_fetches:
+                break
+            sleep(delay)
             json_data = cls.next(json_data["meta"]["next"])
             elements.extend(json_data["data"])
+            fetches += 1
         return elements
 
     @classmethod
@@ -44,11 +49,16 @@ class GenericResource:
         include_api_key: bool = False,
         callback: Callable = None,
         max_fetches: int = 0,
+        delay: float = DELAY_SECONDS,
     ) -> None:
         json_data = cls.list(url, params, include_api_key=include_api_key)
         callback(json_data["data"])
+        fetches = 1
 
         while has_next_url(json_data):
-            sleep(DELAY_SECONDS)
+            if max_fetches > 0 and fetches >= max_fetches:
+                break
+            sleep(delay)
             json_data = cls.next(json_data["meta"]["next"])
             callback(json_data["data"])
+            fetches += 1

--- a/ledgerx/generic_resource.py
+++ b/ledgerx/generic_resource.py
@@ -8,9 +8,11 @@ from ledgerx.util import has_next_url
 
 class GenericResource:
     @classmethod
-    def next(cls, next_url: str):
-        res = HttpClient.get(next_url)
-        return res.json()
+    def next(cls, next_url: str, params: Dict, include_api_key: bool = False):
+        res = HttpClient.get(next_url, params, include_api_key)
+        json_data = res.json()
+        logging.debug(f"next {next_url} got {res} {json_data}")
+        return json_data
 
     @classmethod
     def list(cls, url: str, params: Dict, include_api_key: bool = False):
@@ -36,7 +38,7 @@ class GenericResource:
             if max_fetches > 0 and fetches >= max_fetches:
                 break
             sleep(delay)
-            json_data = cls.next(json_data["meta"]["next"])
+            json_data = cls.next(json_data["meta"]["next"], params, include_api_key)
             elements.extend(json_data["data"])
             fetches += 1
         return elements
@@ -59,6 +61,6 @@ class GenericResource:
             if max_fetches > 0 and fetches >= max_fetches:
                 break
             sleep(delay)
-            json_data = cls.next(json_data["meta"]["next"])
+            json_data = cls.next(json_data["meta"]["next"], params, include_api_key)
             callback(json_data["data"])
             fetches += 1

--- a/ledgerx/generic_resource.py
+++ b/ledgerx/generic_resource.py
@@ -7,6 +7,8 @@ from ledgerx.util import has_next_url
 
 
 class GenericResource:
+    list_all_default_delay = DELAY_SECONDS
+
     @classmethod
     def next(cls, next_url: str, params: Dict, include_api_key: bool = False):
         res = HttpClient.get(next_url, params, include_api_key)
@@ -26,10 +28,11 @@ class GenericResource:
         params: Dict = {},
         include_api_key: bool = False,
         max_fetches: int = 0,
-        delay: float = DELAY_SECONDS,
+        delay: float = -1,
     ) -> List[Dict]:
         elements = []
-
+        if delay < 0:
+            delay = cls.list_all_default_delay
         json_data = cls.list(url, params, include_api_key)
         elements.extend(json_data["data"])
         fetches = 1

--- a/ledgerx/http_client.py
+++ b/ledgerx/http_client.py
@@ -6,8 +6,6 @@ from ledgerx import DELAY_SECONDS
 
 import logging
 
-logging.basicConfig(level=logging.INFO)
-
 class HttpClient:
     # TODO(weston) - handle rate limiting, https://docs.ledgerx.com/reference#rate-limits
 

--- a/ledgerx/http_client.py
+++ b/ledgerx/http_client.py
@@ -8,6 +8,7 @@ import logging
 
 class HttpClient:
     # TODO(weston) - handle rate limiting, https://docs.ledgerx.com/reference#rate-limits
+    RETRY_429_ERRORS = False
 
     @staticmethod
     def get(
@@ -28,7 +29,8 @@ class HttpClient:
         res = None
         while True:
             res = requests.get(url, headers=headers, params=params)
-            if res.status_code == 429:
+            logging.debug(f"get {url} {res}")
+            if HttpClient.RETRY_429_ERRORS and res.status_code == 429:
                 if delay == DELAY_SECONDS:
                     delay += 1
                 else:

--- a/ledgerx/positions.py
+++ b/ledgerx/positions.py
@@ -1,6 +1,7 @@
 from typing import List, Dict
 from ledgerx.http_client import HttpClient
 from ledgerx.util import gen_url
+from ledgerx import DEFAULT_LIMIT
 
 
 class Positions:
@@ -43,14 +44,14 @@ class Positions:
     ### helper methods specific to this API client
 
     @classmethod
-    def list_all(cls, params: Dict = dict() -> List[Dict]:
+    def list_all(cls, params: Dict = dict()) -> List[Dict]:
         include_api_key = True
         url = gen_url("/trading/positions")
         qps = {**cls.default_positions_params, **params}
         return GenericResource.list_all(url, qps, include_api_key)
 
     @classmethod
-    def list_all_trades(cls, position_id: int, params: Dict = dict() -> Dict:
+    def list_all_trades(cls, position_id: int, params: Dict = dict()) -> Dict:
         include_api_key = True
         url = gen_url(f"/trading/positions/{position_id}/trades")
         qps = {**cls.default_trades_params, **params}

--- a/ledgerx/positions.py
+++ b/ledgerx/positions.py
@@ -4,8 +4,8 @@ from ledgerx.util import gen_url
 
 
 class Positions:
-    default_list_params = dict()
-    # default_list_traded = dict(derivative_type=None, asset=None)
+    default_positions_params = dict(limit=DEFAULT_LIMIT)
+    default_trades_params = dict(limit=DEFAULT_LIMIT)
 
     @classmethod
     def list(cls, params: Dict = {}) -> List[Dict]:
@@ -26,18 +26,32 @@ class Positions:
         return res.json()
 
     @classmethod
-    def list_trades(cls, contract_id: int) -> Dict:
+    def list_trades(cls, position_id: int) -> Dict:
         """Returns a list of your trades for a given position.
 
         Args:
-            contract_id (int): LedgerX contract ID.
+            position_id (int): LedgerX contract ID.
 
         Returns:
             Dict: [description]
         """
         include_api_key = True
-        url = gen_url(f"/trading/positions/{contract_id}/trades")
+        url = gen_url(f"/trading/positions/{position_id}/trades")
         res = HttpClient.get(url, {}, include_api_key)
         return res.json()
 
     ### helper methods specific to this API client
+
+    @classmethod
+    def list_all(cls, params: Dict = dict() -> List[Dict]:
+        include_api_key = True
+        url = gen_url("/trading/positions")
+        qps = {**cls.default_positions_params, **params}
+        return GenericResource.list_all(url, qps, include_api_key)
+
+    @classmethod
+    def list_all_trades(cls, position_id: int, params: Dict = dict() -> Dict:
+        include_api_key = True
+        url = gen_url(f"/trading/positions/{position_id}/trades")
+        qps = {**cls.default_trades_params, **params}
+        return GenericResource.list_all(url, qps, include_api_key)

--- a/ledgerx/trades.py
+++ b/ledgerx/trades.py
@@ -8,7 +8,7 @@ class Trades:
     default_list_params = dict(
         status_type=201, limit=50, min_size=1, mine=False, asset="CBTC"
     )
-    default_list_all_params = dict()
+    default_list_all_params = dict(limit=DEFAULT_LIMIT)
 
     @classmethod
     def list(cls, params: Dict = {}) -> List[Dict]:

--- a/ledgerx/trades.py
+++ b/ledgerx/trades.py
@@ -44,7 +44,7 @@ class Trades:
         include_api_key = False
         url = gen_url("/trading/trades/global")
         request_params = {**cls.default_list_all_params, **params}
-        return GenericResource.list_all(url, request_params, include_api_key)
+        return GenericResource.list_all(url, request_params, include_api_key, 0, 6)
 
     # helper methods specific to this API client
 
@@ -68,7 +68,7 @@ class Trades:
         url = gen_url("/trading/trades/global")
         request_params = {**cls.default_list_params, **params}
         return GenericResource.list_all_incremental_return(
-            url, params, include_api_key, callback
+            url, params, include_api_key, callback, 0, 6
         )
 
     @classmethod

--- a/ledgerx/trades.py
+++ b/ledgerx/trades.py
@@ -2,6 +2,7 @@ from typing import List, Dict, Callable
 from ledgerx.http_client import HttpClient
 from ledgerx.util import gen_url
 from ledgerx.generic_resource import GenericResource
+from ledgerx import DEFAULT_LIMIT
 
 
 class Trades:

--- a/ledgerx/trades.py
+++ b/ledgerx/trades.py
@@ -3,6 +3,7 @@ from ledgerx.http_client import HttpClient
 from ledgerx.util import gen_url
 from ledgerx.generic_resource import GenericResource
 from ledgerx import DEFAULT_LIMIT
+from ledgerx import DELAY_SECONDS
 
 
 class Trades:
@@ -10,6 +11,7 @@ class Trades:
         status_type=201, limit=50, min_size=1, mine=False, asset="CBTC"
     )
     default_list_all_params = dict(limit=DEFAULT_LIMIT)
+    default_trading_trades_global_delay = DELAY_SECONDS
 
     @classmethod
     def list(cls, params: Dict = {}) -> List[Dict]:
@@ -45,7 +47,7 @@ class Trades:
         include_api_key = False
         url = gen_url("/trading/trades/global")
         request_params = {**cls.default_list_all_params, **params}
-        return GenericResource.list_all(url, request_params, include_api_key, 0, 6)
+        return GenericResource.list_all(url, request_params, include_api_key, 0, cls.default_trading_trades_global_delay)
 
     # helper methods specific to this API client
 
@@ -69,7 +71,7 @@ class Trades:
         url = gen_url("/trading/trades/global")
         request_params = {**cls.default_list_params, **params}
         return GenericResource.list_all_incremental_return(
-            url, params, include_api_key, callback, 0, 6
+            url, params, include_api_key, callback, 0, cls.default_trading_trades_global_delay
         )
 
     @classmethod

--- a/ledgerx/transactions.py
+++ b/ledgerx/transactions.py
@@ -1,7 +1,8 @@
 from ledgerx.http_client import HttpClient
 from typing import List, Dict
 from ledgerx.util import gen_url
-
+from ledgerx import DEFAULT_LIMIT
+from ledgerx.generic_resource import GenericResource
 
 class Transactions:
     default_list_params = dict()
@@ -25,3 +26,10 @@ class Transactions:
         return res.json()
 
     ### helper methods specific to this API client
+
+    @classmethod
+    def list_all(cls, params: Dict = {}) -> List[Dict]:
+        include_api_key = True
+        url = gen_url("/funds/transactions")
+        qps = {**cls.default_list_params, **params}
+        return GenericResource.list_all(url, qps, include_api_key)


### PR DESCRIPTION
added retry loop to http client when error 429 is returned
added default delay to contracts and trades based on ledgerx specs

Changes include:
- 
